### PR TITLE
Harden column mapping and validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,5 @@ This repository maintains a log of tasks performed by AI agents.
 - Improve column detection and validation to handle missing `time` fields.
 - Add sample dataset and prevent division by zero in spectral calculations.
 - Remove sample XLSX dataset and document local data setup.
+- Harden column mapping by normalizing headers and validating the time field.
 


### PR DESCRIPTION
## Summary
- Normalize header names to handle accents and BOM characters
- Validate mappings to ensure a unique time column and raise clear errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1d210a0108327bf00af2f34aff816